### PR TITLE
Improve sorting: push empty cells to bottom, sort by desc first

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,13 @@
 $(document).ready( function () {
+    // Push empty '-' cells to bottom when sorting
+    const namesType = $.fn.dataTable.absoluteOrder( [
+        { value: '-', position: 'bottom' }
+    ] );
+
+    const numbersType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+    ] );
+
     const options = {
         ajax: {
             url: './trackers.json',
@@ -116,11 +125,24 @@ $(document).ready( function () {
                     if (styles){
                         const labelType = styles.labelType || 'default';
                         const style = styles.style || '';
-                        return `<span class="label label-${labelType}" style="background-color: rgba(26, 26, 26, 1); ${style}"> ${data} </span>`; 
+                        return `<span class="label label-${labelType}" style="background-color: rgba(26, 26, 26, 1); ${style}"> ${data} </span>`;
                     }
 
                     return data;
                 }
+            },
+            {
+                // Sort by descending first for Users, Torrents, Peers and Updated
+                targets: [5, 6, 7, 16],
+                orderSequence: [ "desc", "asc" ]
+            },
+            {
+                targets: [5, 6, 7],
+                type: numbersType
+            },
+            {
+                targets: [1, 3, 4, 8, 9, 10, 11, 12, 13, 14, 15],
+                type: namesType
             }
         ],
         paging: false,

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <!-- jQuery & Datatables -->
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.20/fh-3.1.6/r-2.2.3/sl-1.3.1/datatables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.10.20/sorting/absolute.js"></script>
     <script type="text/javascript" charset="UTF-8" src="assets/js/app.js"></script>
 
     <!-- #FONT-AWESOME -->


### PR DESCRIPTION
Some improvements to default sorting:
- use `absolute.js` plug-in to push empty `-` cells to bottom
- sort by descending first for Users, Torrents, Peers and Updated

References:
- https://datatables.net/blog/2016-12-22
- https://datatables.net/plug-ins/sorting/absolute